### PR TITLE
メンバー追加ポップアップで、メンバーが空の場合に「入力してください」というメッセージが表示されたのちに勝手にポップアップが消える問題

### DIFF
--- a/lib/ui/components/dialog/add_member_dialog.dart
+++ b/lib/ui/components/dialog/add_member_dialog.dart
@@ -19,12 +19,15 @@ class AddMemberDialogState extends ConsumerState<AddMemberDialog> {
   String? _errorMessage;
 
   Future<void> _createMember() async {
-    setState(() {
-      if (_controller.text.trim().isEmpty) {
+    if (_controller.text.trim().isEmpty) {
+      setState(() {
         _errorMessage = 'メンバーを入力してください';
-      } else {
-        _errorMessage = null;
-      }
+      });
+      return;
+    }
+
+    setState(() {
+      _errorMessage = null;
     });
 
     try {
@@ -81,10 +84,10 @@ class AddMemberDialogState extends ConsumerState<AddMemberDialog> {
                       //LINE認証申請前の臨時ダイアログ
                       showDialog(
                         context: context,
-                        builder: (context) => AlertDialog(
-                          contentPadding: const EdgeInsets.symmetric(
+                        builder: (context) => const AlertDialog(
+                          contentPadding: EdgeInsets.symmetric(
                               vertical: 56.0, horizontal: 24.0),
-                          content: const Text(
+                          content: Text(
                             'LINEへの認証申請中のため、\n機能解禁までしばらくお待ちください',
                             textAlign: TextAlign.center,
                           ),


### PR DESCRIPTION
returnを追加し、メンバーが空の場合にポップアップを閉じる部分までコードが行かないように変更

- Close #84 